### PR TITLE
<home /> components separated

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -33,7 +33,8 @@ const App = () => {
       routes = (
       <Switch>
             <Route path="/dashboard">
-                <Dashboard />
+                {/* <Dashboard /> */}
+                <Home />
             </Route>
             <Redirect to="/dashboard" />
         </Switch>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Grid from "@material-ui/core/Grid";
 
@@ -11,6 +11,7 @@ import RecentTransactions from '../shared/components/general/RecentTransactions'
 import { MonthSelector } from '../shared/components/general/MonthSelector';
 
 export function Dashboard(props) {
+  const { receiptCount } = props;
   return (
     <>
       <Grid container spacing={3} xs={12} lg={10}>
@@ -23,7 +24,7 @@ export function Dashboard(props) {
         <Grid item xs={12} md={6}>
           <Panel title="TOP CATEGORIES">
             {/* <CatStatTable /> */}
-            <TopCategories />
+            <TopCategories receiptCount={receiptCount} />
           </Panel>
         </Grid>
       </Grid>
@@ -37,7 +38,7 @@ export function Dashboard(props) {
           <Panel>
             {/* <TransactionTable /> */}
             {/* <RecentTransactions reloadTrans={setReloadTransactions}/> */}
-            <RecentTransactions />
+            <RecentTransactions receiptCount={receiptCount} />
           </Panel>
         </Grid>
       </Grid>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,28 +1,17 @@
 import React, { useState, useEffect } from "react";
 
-import AppBar from "@material-ui/core/AppBar";
 import Box from "@material-ui/core/Box";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import Drawer from "@material-ui/core/Drawer";
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import Toolbar from "@material-ui/core/Toolbar";
 import Grid from "@material-ui/core/Grid";
-import FiberManualRecordIcon from "@material-ui/icons/FiberManualRecord";
 
 import {
   BrowserRouter as Router,
   Switch,
-  Route,
-  Link
+  Route
 } from "react-router-dom";
 
-import { LoginUploadBtn } from '../shared/components/general/LoginUploadBtn';
-import { ProfileAvator } from '../shared/components/general/ProfileAvator';
-import { Logo } from '../shared/components/general/Logo';
+import { Header } from '../shared/components/HeaderElements/Header';
 
-import AppDialog from '../shared/components/UIElements/AppDialog.js';
-import ReceiptUploadForm from '../receipts/components/ReceiptUpload';
 import ErrorModal from '../shared/components/UIElements/ErrorModal';
 import LoadingSpinner from '../shared/components/UIElements/LoadingSpinner';
 import { useHttpClient } from '../shared/hooks/http-hook';
@@ -31,76 +20,12 @@ import { Dashboard } from './Dashboard';
 import { Reports } from './Reports';
 import { Receipts } from './Receipts';
 
-import logo from '../assets/logo.png';
-
 import { theme } from '../themes/theme';
 
 import { ThemeProvider } from '@material-ui/core/styles';
-import { useTheme } from '@material-ui/core/styles';
-import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { makeStyles } from "@material-ui/core/styles";
 
-const drawerWidth = "15rem";
-
 const useStyles = makeStyles(theme => ({
-  invisible: {
-    visibility: 'hidden'
-  },
-  hidden: {
-    display: 'none'
-  },
-  btnOnfocus: {
-    backgroundColor: '#4366a7',
-    color: '#38cc89'
-  },
-  drawer: {
-    [theme.breakpoints.up("sm")]: {
-      width: drawerWidth,
-      flexShrink: 0
-    }
-  },
-  tabs: {
-    marginTop: theme.spacing(3)
-  },
-  tabRoot: {
-    width: '70%',
-    margin: '0.4rem auto',
-    borderRadius: '0.5rem',
-    minHeight: '2rem',
-    textTransform: 'none'
-  },
-  tabWrapper: {
-    flexDirection: 'row',
-    justifyContent: 'normal',
-    alignItems: 'baseline'
-  },
-  tabIcon: {
-    marginRight: '1rem',
-    marginBottom: 0,
-    fontSize: '0.7rem'
-  },
-  appBar: {
-    [theme.breakpoints.up("sm")]: {
-      width: `calc(100% - ${drawerWidth})`,
-      marginLeft: drawerWidth
-    }
-  },
-  toolbar: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    backgroundColor: '#fafafa',
-    color: 'initial'
-  },
-  menuButton: {
-    width: '2rem',
-    marginLeft: '0.8rem',
-    marginRight: 'auto',
-    borderRadius: '50%',
-    cursor: 'pointer',
-    [theme.breakpoints.up("sm")]: {
-      display: "none"
-    }
-  },
   utilbar: {
     ...theme.mixins.toolbar,
     backgroundColor: '#314f85',
@@ -108,26 +33,6 @@ const useStyles = makeStyles(theme => ({
   },
   utilbarMain: {
     backgroundColor: '#fafafa'
-  },
-  drawerPaper: {
-    width: drawerWidth,
-    backgroundColor: '#1b3460',
-    color: '#fafafa'
-  },
-  logoContainer: {
-    ...theme.mixins.toolbar,
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: '100%',
-    margin: 0
-  },
-  logo: {
-    width: '15%',
-    marginRight: '2rem'
   },
   main: {
     display: 'flex',
@@ -148,59 +53,26 @@ const useStyles = makeStyles(theme => ({
 export function Home(props) {
   const classes = useStyles();
   const { isLoading, error, sendRequest, clearError } = useHttpClient();
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
-  const [page, setPage] = useState('Dashboard');
-  const [reloadTransactions, setReloadTransactions] = useState(false);
-
-  const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
+  const [page, setPage] = useState('');
 
   const handleChange = (e, page) => {
     setPage(page);
   };
 
-  const handleDialogOpen = () => {
-    setIsOpen(true);
-  };
-
-  const handleDialogClose = () => {
-    setIsOpen(false);
-  };
-
-  const handleClickOpen = () => {
-    setIsOpen(true);
-  };
-
-  const data = [
-    {
-      id: "0",
-      name: "Select Category"
-    },
-    {
-      id: "Food & Drinks",
-      name: "Food & Drinks"
-    },
-    {
-      id: "Housing",
-      name: "Housing"
-    },
-    {
-      id: "Transportation",
-      name: "Transportation"
-    },
-    {
-      id: "Health Care",
-      name: "Health Care"
-    },
-    {
-      id: "Recreation & Entertainment",
-      name: "Recreation & Entertainment"
-    },
-    {
-      id: "Grocery",
-      name: "Grocery"
+  // Stay in the previous page after refreshing, or go to Dashboard at the first entry
+  useEffect(() => {
+    const prevPage = sessionStorage.getItem('page');
+    if (prevPage) {
+      setPage(prevPage);
+    } else {
+      sessionStorage.setItem('page', 'Dashboard');
+      setPage('Dashboard');
     }
-  ];
+  }, []);
+
+  useEffect(() => {
+    sessionStorage.setItem('page', page);
+  }, [page])
 
   const pages = [
     { name: 'Dashboard', component: <Dashboard /> },
@@ -208,97 +80,13 @@ export function Home(props) {
     { name: 'Receipts', component: <Receipts /> },
   ];
 
-  const isMobile = useMediaQuery(useTheme().breakpoints.down('xs'));
-
-  useEffect(() => {
-    const page = sessionStorage.getItem('page') || 'Dashboard';
-    setPage(page);
-  }, []);
-
-  useEffect(() => {
-    sessionStorage.setItem('page', page);
-  }, [page])
 
   return (
     <Router>
       <Box display="flex">
         <CssBaseline />
         <ThemeProvider theme={theme}>
-          <header>
-            <AppBar className={classes.appBar}>
-              <Toolbar className={classes.toolbar}>
-                <img
-                  src={logo}
-                  alt="logo"
-                  className={classes.menuButton}
-                  onClick={handleDrawerToggle}
-                />
-                <LoginUploadBtn onClick={handleClickOpen}>Upload Receipt</LoginUploadBtn>
-                <ProfileAvator />
-              </Toolbar>
-            </AppBar>
-            <nav className={classes.drawer}>
-              <Drawer
-                classes={{
-                  paper: classes.drawerPaper
-                }}
-                {...(isMobile ? {
-                  variant: "temporary",
-                  open: mobileOpen,
-                  ModalProps: {
-                    keepMounted: true,
-                    BackdropProps: {
-                      invisible: true
-                    }
-                  },
-                  onClose: handleDrawerToggle
-                } : {
-                    variant: "permanent",
-                    open: true
-                  }
-                )}
-              >
-                <div className={classes.utilbar}></div>
-                <Logo title logoStyle={classes} />
-                <Tabs
-                  orientation="vertical"
-                  value={page}
-                  className={classes.tabs}
-                  classes={{
-                    indicator: classes.hidden
-                  }}
-                  onChange={handleChange}
-                  onClick={isMobile ? handleDrawerToggle : null}
-                >
-                  {pages.map(tab => {
-                    const { name } = tab;
-                    return (
-                      <Tab
-                        key={name}
-                        component={Link}
-                        to={`/${name.toLowerCase()}`}
-                        icon={
-                          <FiberManualRecordIcon className={
-                            `${classes.tabIcon} ${name === page || classes.invisible}`
-                          } />
-                        }
-                        label={name}
-                        value={name}
-                        classes={{
-                          root: classes.tabRoot,
-                          wrapper: classes.tabWrapper,
-                          selected: classes.btnOnfocus
-                        }}
-                      />
-                    )
-                  })}
-                </Tabs>
-              </Drawer>
-            </nav>
-            <AppDialog size="md" isOpen={isOpen} handleOpen={handleDialogOpen} handleClose={handleDialogClose} title='Upload receipt'>
-              <ReceiptUploadForm data={data} reloadTrans={setReloadTransactions} ></ReceiptUploadForm>
-            </AppDialog>
-          </header >
+          <Header page={page} onChange={handleChange} />
           <main className={classes.main}>
             <ErrorModal error={error} onClear={clearError} />
             {isLoading && <LoadingSpinner asOverlay />}
@@ -320,7 +108,7 @@ export function Home(props) {
             </Switch>
           </main>
         </ThemeProvider>
-      </Box>
-    </Router>
+      </Box >
+    </Router >
   )
 }

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
 import Box from "@material-ui/core/Box";
 import CssBaseline from "@material-ui/core/CssBaseline";
@@ -53,26 +53,11 @@ const useStyles = makeStyles(theme => ({
 export function Home(props) {
   const classes = useStyles();
   const { isLoading, error, sendRequest, clearError } = useHttpClient();
-  const [page, setPage] = useState('');
+  const [page, setPage] = useState('Dashboard');
 
   const handleChange = (e, page) => {
     setPage(page);
   };
-
-  // Stay in the previous page after refreshing, or go to Dashboard at the first entry
-  useEffect(() => {
-    const prevPage = sessionStorage.getItem('page');
-    if (prevPage) {
-      setPage(prevPage);
-    } else {
-      sessionStorage.setItem('page', 'Dashboard');
-      setPage('Dashboard');
-    }
-  }, []);
-
-  useEffect(() => {
-    sessionStorage.setItem('page', page);
-  }, [page])
 
   const pages = [
     { name: 'Dashboard', component: <Dashboard /> },

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -54,13 +54,19 @@ export function Home(props) {
   const classes = useStyles();
   const { isLoading, error, sendRequest, clearError } = useHttpClient();
   const [page, setPage] = useState('Dashboard');
+  const [receiptCount, setReceiptCount] = useState(0);
 
+  const handleReceiptUpload = () => {
+    setReceiptCount(receiptCount + 1);
+    // const currState =  reloadTransactions === false ? true: reloadTransactions;
+    //setReloadTransactions(currState);
+  };
   const handleChange = (e, page) => {
     setPage(page);
   };
 
   const pages = [
-    { name: 'Dashboard', component: <Dashboard /> },
+    { name: 'Dashboard', component: <Dashboard receiptCount={receiptCount} /> },
     { name: 'Reports', component: <Reports /> },
     { name: 'Receipts', component: <Receipts /> },
   ];
@@ -71,7 +77,11 @@ export function Home(props) {
       <Box display="flex">
         <CssBaseline />
         <ThemeProvider theme={theme}>
-          <Header page={page} onChange={handleChange} />
+          <Header
+            page={page}
+            onChange={handleChange}
+            onReceiptUpload={handleReceiptUpload}
+          />
           <main className={classes.main}>
             <ErrorModal error={error} onClear={clearError} />
             {isLoading && <LoadingSpinner asOverlay />}

--- a/client/src/shared/components/HeaderElements/Header.js
+++ b/client/src/shared/components/HeaderElements/Header.js
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+
+import { TopBar } from './TopBar';
+import { SideBar } from './SideBar';
+import { NavTabs } from './NavTabs';
+import { LoginUploadBtn } from './LoginUploadBtn';
+import { ProfileAvatar } from './ProfileAvatar';
+import { MenuBtn } from './MenuBtn';
+import { Logo } from '../general/Logo';
+
+import AppDialog from '../UIElements/AppDialog.js';
+import ReceiptUploadForm from '../../../receipts/components/ReceiptUpload';
+
+import { useTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(theme => ({
+  logoContainer: {
+    ...theme.mixins.toolbar,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    margin: 0
+  },
+  logo: {
+    width: '15%',
+    marginRight: '2rem'
+  }
+}));
+
+export function Header(props) {
+  const classes = useStyles();
+
+  const isMobile = useMediaQuery(useTheme().breakpoints.down('xs'));
+
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [reloadTransactions, setReloadTransactions] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  }
+  const handleDialogOpen = () => {
+    setIsOpen(true);
+  };
+  const handleDialogClose = () => {
+    setIsOpen(false);
+  };
+
+  const data = [
+    {
+      id: "0",
+      name: "Select Category"
+    },
+    {
+      id: "Food & Drinks",
+      name: "Food & Drinks"
+    },
+    {
+      id: "Housing",
+      name: "Housing"
+    },
+    {
+      id: "Transportation",
+      name: "Transportation"
+    },
+    {
+      id: "Health Care",
+      name: "Health Care"
+    },
+    {
+      id: "Recreation & Entertainment",
+      name: "Recreation & Entertainment"
+    },
+    {
+      id: "Grocery",
+      name: "Grocery"
+    }
+  ];
+
+  return (
+    <header>
+      <TopBar>
+        <MenuBtn onClick={handleDrawerToggle} />
+        <LoginUploadBtn onClick={handleDialogOpen}>Upload Receipt</LoginUploadBtn>
+        <ProfileAvatar />
+      </TopBar>
+      <SideBar open={mobileOpen} onClose={handleDrawerToggle}>
+        <Logo title logoStyle={classes} />
+        <NavTabs
+          value={props.page}
+          onChange={props.onChange}
+          onClick={isMobile ? handleDrawerToggle : null}
+        />
+      </SideBar>
+      <AppDialog
+        size="md"
+        isOpen={isOpen}
+        handleOpen={handleDialogOpen}
+        handleClose={handleDialogClose}
+        title='Upload receipt'
+      >
+        <ReceiptUploadForm data={data} reloadTrans={setReloadTransactions} />
+      </AppDialog>
+    </header >
+  )
+}

--- a/client/src/shared/components/HeaderElements/Header.js
+++ b/client/src/shared/components/HeaderElements/Header.js
@@ -15,6 +15,8 @@ import { useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { makeStyles } from "@material-ui/core/styles";
 
+const drawerWidth = "15rem";
+
 const useStyles = makeStyles(theme => ({
   logoContainer: {
     ...theme.mixins.toolbar,
@@ -85,12 +87,16 @@ export function Header(props) {
 
   return (
     <header>
-      <TopBar>
+      <TopBar drawerWidth={drawerWidth}>
         <MenuBtn onClick={handleDrawerToggle} />
         <LoginUploadBtn onClick={handleDialogOpen}>Upload Receipt</LoginUploadBtn>
         <ProfileAvatar />
       </TopBar>
-      <SideBar open={mobileOpen} onClose={handleDrawerToggle}>
+      <SideBar
+        drawerWidth={drawerWidth}
+        open={mobileOpen}
+        onClose={handleDrawerToggle}
+      >
         <Logo title logoStyle={classes} />
         <NavTabs
           value={props.page}

--- a/client/src/shared/components/HeaderElements/Header.js
+++ b/client/src/shared/components/HeaderElements/Header.js
@@ -53,6 +53,9 @@ export function Header(props) {
   const handleDialogClose = () => {
     setIsOpen(false);
   };
+  const handleReceiptUpload = () => {
+    props.onReceiptUpload();
+  };
 
   const data = [
     {
@@ -111,7 +114,11 @@ export function Header(props) {
         handleClose={handleDialogClose}
         title='Upload receipt'
       >
-        <ReceiptUploadForm data={data} reloadTrans={setReloadTransactions} />
+        <ReceiptUploadForm
+          data={data}
+          reloadTrans={reloadTransactions}
+          onReceiptUpload={handleReceiptUpload}
+        />
       </AppDialog>
     </header >
   )

--- a/client/src/shared/components/HeaderElements/LoginUploadBtn.js
+++ b/client/src/shared/components/HeaderElements/LoginUploadBtn.js
@@ -25,19 +25,14 @@ export function LoginUploadBtn(props) {
   const classes = useStyles();
   const isMobile = useMediaQuery(useTheme().breakpoints.down('xs'));
 
-  const buttonProps = {
-    className: classes.btnLoginUpload,
-    onClick: props.onClick
-  };
-
   return (
     isMobile ?
       (
         <IconButton>
-          <ReceiptIcon {...buttonProps} />
+          <ReceiptIcon className={classes.btnLoginUpload} {...props} />
         </IconButton>
       ) : (
-        <Button variant="outlined" {...buttonProps}>{props.children}</Button>
+        <Button variant="outlined" className={classes.btnLoginUpload} {...props}>{props.children}</Button>
       )
   )
 }

--- a/client/src/shared/components/HeaderElements/MenuBtn.js
+++ b/client/src/shared/components/HeaderElements/MenuBtn.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { Hidden } from "@material-ui/core";
+
+import logo from '../../../assets/logo.png';
+
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  menuButton: {
+    width: '2rem',
+    marginLeft: '0.8rem',
+    marginRight: 'auto',
+    borderRadius: '50%',
+    cursor: 'pointer',
+  }
+})
+
+export function MenuBtn(props) {
+  const classes = useStyles();
+  return (
+    <Hidden smUp>
+      <img
+        src={logo}
+        alt="logo"
+        className={classes.menuButton}
+        {...props}
+      />
+    </Hidden>
+  )
+}

--- a/client/src/shared/components/HeaderElements/NavTabs.js
+++ b/client/src/shared/components/HeaderElements/NavTabs.js
@@ -1,0 +1,79 @@
+import React from "react";
+
+import { Link } from "react-router-dom";
+
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import FiberManualRecordIcon from "@material-ui/icons/FiberManualRecord";
+
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(theme => ({
+  hidden: {
+    display: 'none'
+  },
+  invisible: {
+    visibility: 'hidden'
+  },
+  tabs: {
+    marginTop: theme.spacing(3)
+  },
+  tabRoot: {
+    width: '70%',
+    margin: '0.4rem auto',
+    borderRadius: '0.5rem',
+    minHeight: '2rem',
+    textTransform: 'none'
+  },
+  tabWrapper: {
+    flexDirection: 'row',
+    justifyContent: 'normal',
+    alignItems: 'baseline'
+  },
+  tabIcon: {
+    marginRight: '1rem',
+    marginBottom: 0,
+    fontSize: '0.7rem'
+  },
+  btnOnfocus: {
+    backgroundColor: '#4366a7',
+    color: '#38cc89'
+  },
+}));
+
+export function NavTabs(props) {
+  const classes = useStyles();
+
+  return (
+    <Tabs
+      orientation="vertical"
+      className={classes.tabs}
+      classes={{
+        indicator: classes.hidden
+      }}
+      {...props}
+    >
+      {['Dashboard', 'Reports', 'Receipts'].map(tab => {
+        return (
+          <Tab
+            key={tab}
+            component={Link}
+            to={`/${tab.toLowerCase()}`}
+            icon={
+              <FiberManualRecordIcon className={
+                `${classes.tabIcon} ${tab === props.value || classes.invisible}`
+              } />
+            }
+            label={tab}
+            value={tab}
+            classes={{
+              root: classes.tabRoot,
+              wrapper: classes.tabWrapper,
+              selected: classes.btnOnfocus
+            }}
+          />
+        )
+      })}
+    </Tabs>
+  )
+}

--- a/client/src/shared/components/HeaderElements/ProfileAvatar.js
+++ b/client/src/shared/components/HeaderElements/ProfileAvatar.js
@@ -16,7 +16,7 @@ const useStyles = makeStyles(theme => ({
       margin: 0
     }
   },
-  avator: {
+  avatar: {
     marginRight: '1rem'
   },
   text: {
@@ -26,11 +26,11 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export function ProfileAvator(props) {
+export function ProfileAvatar(props) {
   const classes = useStyles();
   return (
     <div className={classes.container}>
-      <Avatar alt="User Avator" src={User} className={classes.avator} />
+      <Avatar alt="User Avatar" src={User} className={classes.avatar} />
       <div className={classes.text}>Profile</div>
     </div>
   )

--- a/client/src/shared/components/HeaderElements/SideBar.js
+++ b/client/src/shared/components/HeaderElements/SideBar.js
@@ -1,0 +1,61 @@
+import React from "react";
+
+import Drawer from "@material-ui/core/Drawer";
+
+import { useTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { makeStyles } from "@material-ui/core/styles";
+
+const drawerWidth = "15rem";
+
+const useStyles = makeStyles(theme => ({
+  drawer: {
+    [theme.breakpoints.up("sm")]: {
+      width: drawerWidth,
+      flexShrink: 0
+    }
+  },
+  utilbar: {
+    ...theme.mixins.toolbar,
+    backgroundColor: '#314f85',
+    opacity: 0.4,
+  },
+  drawerPaper: {
+    width: drawerWidth,
+    backgroundColor: '#1b3460',
+    color: '#fafafa'
+  }
+}));
+
+export function SideBar(props) {
+  const classes = useStyles();
+
+  const isMobile = useMediaQuery(useTheme().breakpoints.down('xs'));
+
+  return (
+    <nav className={classes.drawer}>
+      <Drawer
+        classes={{
+          paper: classes.drawerPaper
+        }}
+        {...(isMobile ? {
+          variant: "temporary",
+          ModalProps: {
+            keepMounted: true,
+            BackdropProps: {
+              invisible: true
+            }
+          },
+          ...props
+        } : {
+            variant: "permanent",
+            open: true
+          }
+        )}
+      >
+        <div className={classes.utilbar}></div>
+        {props.children}
+      </Drawer>
+    </nav>
+  )
+}

--- a/client/src/shared/components/HeaderElements/SideBar.js
+++ b/client/src/shared/components/HeaderElements/SideBar.js
@@ -6,12 +6,10 @@ import { useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { makeStyles } from "@material-ui/core/styles";
 
-const drawerWidth = "15rem";
-
 const useStyles = makeStyles(theme => ({
   drawer: {
     [theme.breakpoints.up("sm")]: {
-      width: drawerWidth,
+      width: ({ drawerWidth }) => drawerWidth,
       flexShrink: 0
     }
   },
@@ -21,14 +19,15 @@ const useStyles = makeStyles(theme => ({
     opacity: 0.4,
   },
   drawerPaper: {
-    width: drawerWidth,
+    width: ({ drawerWidth }) => drawerWidth,
     backgroundColor: '#1b3460',
     color: '#fafafa'
   }
 }));
 
 export function SideBar(props) {
-  const classes = useStyles();
+  const { drawerWidth, open, onClose, children } = props;
+  const classes = useStyles({ drawerWidth });
 
   const isMobile = useMediaQuery(useTheme().breakpoints.down('xs'));
 
@@ -46,7 +45,8 @@ export function SideBar(props) {
               invisible: true
             }
           },
-          ...props
+          open,
+          onClose
         } : {
             variant: "permanent",
             open: true
@@ -54,7 +54,7 @@ export function SideBar(props) {
         )}
       >
         <div className={classes.utilbar}></div>
-        {props.children}
+        {children}
       </Drawer>
     </nav>
   )

--- a/client/src/shared/components/HeaderElements/TopBar.js
+++ b/client/src/shared/components/HeaderElements/TopBar.js
@@ -5,13 +5,11 @@ import Toolbar from "@material-ui/core/Toolbar";
 
 import { makeStyles } from "@material-ui/core/styles";
 
-const drawerWidth = "15rem";
-
 const useStyles = makeStyles(theme => ({
   appBar: {
     [theme.breakpoints.up("sm")]: {
-      width: `calc(100% - ${drawerWidth})`,
-      marginLeft: drawerWidth
+      width: ({ drawerWidth }) => `calc(100% - ${drawerWidth})`,
+      marginLeft: ({ drawerWidth }) => drawerWidth
     }
   },
   toolbar: {
@@ -23,11 +21,12 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export function TopBar(props) {
-  const classes = useStyles();
+  const { drawerWidth, children } = props;
+  const classes = useStyles({ drawerWidth });
   return (
     <AppBar className={classes.appBar}>
       <Toolbar className={classes.toolbar}>
-        {props.children}
+        {children}
       </Toolbar>
     </AppBar>
   )

--- a/client/src/shared/components/HeaderElements/TopBar.js
+++ b/client/src/shared/components/HeaderElements/TopBar.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+import AppBar from "@material-ui/core/AppBar";
+import Toolbar from "@material-ui/core/Toolbar";
+
+import { makeStyles } from "@material-ui/core/styles";
+
+const drawerWidth = "15rem";
+
+const useStyles = makeStyles(theme => ({
+  appBar: {
+    [theme.breakpoints.up("sm")]: {
+      width: `calc(100% - ${drawerWidth})`,
+      marginLeft: drawerWidth
+    }
+  },
+  toolbar: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    backgroundColor: '#fafafa',
+    color: 'initial'
+  }
+}));
+
+export function TopBar(props) {
+  const classes = useStyles();
+  return (
+    <AppBar className={classes.appBar}>
+      <Toolbar className={classes.toolbar}>
+        {props.children}
+      </Toolbar>
+    </AppBar>
+  )
+}

--- a/client/src/shared/components/general/RecentTransactions.js
+++ b/client/src/shared/components/general/RecentTransactions.js
@@ -49,7 +49,6 @@ const RecentTransactions = (props) => {
         sendRequest,
     } = useHttpClient();
     const userId = auth.userId;
-    console.log(props.reloadTrans);
 
     //Get category icon based upon the category
     const categoryIcon = (category) => {
@@ -84,10 +83,11 @@ const RecentTransactions = (props) => {
                     Authorization: 'Bearer ' + auth.token,
                 });
                 setloadedReceipts(responseData.receipts); // set the transactions data
+                // props.onReceiptUpload();
             } catch (err) { }
         };
         fetchTransactions();
-    }, [sendRequest, userId]);
+    }, [sendRequest, userId, props.receiptCount]);
 
     return (
         <TableContainer>

--- a/client/src/shared/components/general/TopCategories.js
+++ b/client/src/shared/components/general/TopCategories.js
@@ -44,7 +44,7 @@ export default function TopCategories(props) {
     sendRequest,
   } = useHttpClient();
   const userId = auth.userId;
-  const [loadedReceipts, setloadedReceipts] = useState([]);
+  const [loadedCategories, setloadedCategories] = useState([]);
   //Get category icon based upon the category
   const categoryIcon = (category) => {
     switch (category) {
@@ -68,7 +68,7 @@ export default function TopCategories(props) {
 
   // Fetch recent transations
   useEffect(() => {
-    const fetchTransactions = async () => {
+    const fetchTopCategories = async () => {
       try {
         // API call
         const endpoint =
@@ -77,16 +77,16 @@ export default function TopCategories(props) {
         const responseData = await sendRequest(endpoint, 'GET', null, {
           Authorization: 'Bearer ' + auth.token,
         });
-        setloadedReceipts(responseData.receipts); // set the transactions data
+        setloadedCategories(responseData.receipts); // set the transactions data
       } catch (err) { }
     };
-    fetchTransactions();
-  }, [sendRequest, userId]);
+    fetchTopCategories();
+  }, [sendRequest, userId, props.receiptCount]);
   return (
     <TableContainer>
       <Table className={classes.container}>
         <TableBody>
-          {loadedReceipts.map((receipt, index) => (
+          {loadedCategories.map((receipt, index) => (
             <TableRow key={index + ' ' + receipt._id}>
               <TableCell component="th" scope="row">
                 <div className={classes.thead}>


### PR DESCRIPTION
One issue:

~~I use `useEffect` plus `sessionStorage` to let the users stay in the current page if they refresh the page.~~

~~But now after refreshing, the router will change the url to `/dashboard` and redirect to `<Dashboard />`.~~

<hr>

Update:

I merge Varun's changes in the Tables and AppDialog. Please check since I separate the states.

I lift the `receiptCount` state to `<Home />` since I think all pages will share the same state (i.e. tables in all pages will render the real-time data once receipt uploaded)